### PR TITLE
[Rerun SDK] Add recipe

### DIFF
--- a/recipes/rerun_sdk/all/conandata.yml
+++ b/recipes/rerun_sdk/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.24.1":
+    url: "https://github.com/rerun-io/rerun/releases/download/0.24.1/rerun_cpp_sdk.zip"
+    sha256: "6d1b95fe17b73c96c2092f4994e490875fc1c16a3c909157b069f0900b24469b"

--- a/recipes/rerun_sdk/all/conanfile.py
+++ b/recipes/rerun_sdk/all/conanfile.py
@@ -1,0 +1,70 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools import files
+from conan.errors import ConanInvalidConfiguration
+
+import os
+
+class Package(ConanFile):
+    name = "rerun_sdk"
+
+    homepage = "https://github.com/rerun-io/rerun"
+    description = "Visualize streams of multimodal data. Free, fast, easy to use, and simple to integrate. Built in Rust."
+    topics = (name, "ftp", "server")
+    license = ("Apache-2.0", "MIT")
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    def _get_additional_lib(self):
+        if self.settings.arch == "x86_64":
+            if self.settings.os == "Linux":
+                return "librerun_c__linux_x64.a"
+            elif self.settings.os == "Windows":
+                return "rerun_c__win_x64.lib"
+            elif self.settings.os == "Macos":
+                return "librerun_c__macos_x64.a"
+        elif self.settings.arch == "arm64":
+            if self.settings.os == "Linux":
+                return "librerun_c__linux_arm64.a"
+            elif self.settings.os == "Macos":
+                return "librerun_c__macos_arm64.a"
+            
+        return None
+
+    def validate(self):
+        if self._get_additional_lib() is None:
+            raise ConanInvalidConfiguration(f"Unsupported combination of architecture {self.settings.arch} and os {self.settings.os}")
+
+
+    def requirements(self):
+        self.requires("arrow/21.0.0", options={"with_thrift": False, "parquet": False})
+
+    def layout(self):
+        cmake_layout(self)
+
+    def source(self):
+        files.get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        
+        tc = CMakeToolchain(self)
+        tc.variables["RERUN_DOWNLOAD_AND_BUILD_ARROW"] = "OFF"
+        tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = "ON"
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        # Remove installed cmake config files       
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["rerun_sdk", self._get_additional_lib()]

--- a/recipes/rerun_sdk/all/test_package/CMakeLists.txt
+++ b/recipes/rerun_sdk/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(rerun_sdk REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE rerun_sdk::rerun_sdk)

--- a/recipes/rerun_sdk/all/test_package/conanfile.py
+++ b/recipes/rerun_sdk/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/rerun_sdk/all/test_package/test_package.cpp
+++ b/recipes/rerun_sdk/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <rerun.hpp>
+#include <iostream>
+
+int main()
+{
+	std::cout << "rerun version: " << rerun::version_string() << std::endl;
+	rerun::check_binary_and_header_version_match().throw_on_failure();
+
+	return 0;
+}

--- a/recipes/rerun_sdk/config.yml
+++ b/recipes/rerun_sdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.24.1":
+    folder: all


### PR DESCRIPTION
### Summary
Add rerun_sdk conan package (https://github.com/rerun-io/rerun)

#### Motivation
I think rerun is quite a nice tool and as I created this package for work I thought it would be good to share it here.
There are also two issues in the rerun-project on the subject:
- https://github.com/rerun-io/rerun/issues/4420
- https://github.com/rerun-io/rerun/issues/4579
The first contains a link to a conan package created by another contributor
(https://github.com/flightwave/rerun/blob/main/rerun_cpp/conanfile.py)
I haven't taken much from it, yet, because I started to create the recipe without being aware of this,
but maybe it comes in handy when something is missing from my changes.

#### Details
I tried to keep the package very basic. 
It only depends on arrow - however, I deactivated thrift and parquet because for my purposes I didn't need it.
In general, I'm not sure which parameters to set for arrow.
The rerun sdk comes with a cmake file to download arrow (cf. https://github.com/rerun-io/rerun/blob/main/rerun_cpp/download_and_build_arrow.cmake#L99) - from this I figured that boost should be included.

I also activated `CMAKE_POSITION_INDEPENDENT_CODE` by default - let me know if it would be better to make this optional. Or if I should also include functionality to include shared libraries.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
